### PR TITLE
Use x86_64 opam

### DIFF
--- a/org.freedesktop.Sdk.Extension.ocaml.yaml
+++ b/org.freedesktop.Sdk.Extension.ocaml.yaml
@@ -29,8 +29,8 @@ modules:
         dest-filename: opam
         only-arches:
           - x86_64
-        url: https://github.com/ocaml/opam/releases/download/2.2.1/opam-2.2.1-i686-linux
-        sha256: 9f5ba8f92b2fb80e5740c945d3826f656638696711d3adda6b8ef7e62243bf9d
+        url: https://github.com/ocaml/opam/releases/download/2.2.1/opam-2.2.1-x86_64-linux
+        sha256: 01d6a02adcfe978f7a2ee5f82aa8e807e0ac26cf6bb8b4ede4781318b6405e3f
       - type: file
         dest-filename: opam
         only-arches:


### PR DESCRIPTION
This pull request change the url of OPAM from i686 to x86_64. See #6 for more information.


close #6 