### PR TITLE
build and install dune libraries

### DIFF
--- a/ocaml-dune-no-lwt.patch
+++ b/ocaml-dune-no-lwt.patch
@@ -1,0 +1,31 @@
+--- dune-3.15.0/dune-file.orig	2024-04-03 03:29:40.000000000 -0600
++++ dune-3.15.0/dune-file	2024-04-05 08:48:56.083804773 -0600
+@@ -30,9 +30,6 @@
+  (copy dune-private-libs.opam.template ordering.opam.template))
+ 
+ (rule
+- (copy dune-private-libs.opam.template dune-rpc-lwt.opam.template))
+-
+-(rule
+  (copy dune-private-libs.opam.template fiber.opam.template))
+ 
+ (rule
+--- dune-3.15.0/dune-project.orig	2024-04-03 03:29:40.000000000 -0600
++++ dune-3.15.0/dune-project	2024-04-05 08:49:50.546090649 -0600
+@@ -149,16 +149,6 @@ understood by dune language."))
+  (description "Library to connect and control a running dune instance"))
+ 
+ (package
+- (name dune-rpc-lwt)
+- (synopsis "Communicate with dune using rpc and Lwt")
+- (depends
+-  (dune-rpc (= :version))
+-  (csexp (>= 1.5.0))
+-  (lwt (>= 5.6.0))
+-  base-unix)
+- (description "Specialization of dune-rpc to Lwt"))
+-
+-(package
+  (name dyn)
+  (synopsis "Dynamic type")
+  (depends

--- a/org.freedesktop.Sdk.Extension.ocaml.yaml
+++ b/org.freedesktop.Sdk.Extension.ocaml.yaml
@@ -54,9 +54,25 @@ modules:
       - type: archive
         url: https://github.com/ocaml/dune/archive/refs/tags/3.16.0.tar.gz
         sha256: cf141fe2113d95faab9714bc3203f4665ba58c7e0c4450f9a719f1ba075cd214
+      # bootstrapping problem: dune-rpc-lwt requires lwt requires dune
+      - type: patch
+        path: ocaml-dune-no-lwt.patch
     build-commands:
+      - rm -fr otherlibs/dune-rpc-lwt dune-rpc-lwt.opam
+      # configure doesn't know prefix?
+      - ./configure
+          --bindir=${FLATPAK_DEST}/bin
+          --sbindir=${FLATPAK_DEST}/bin
+          --libdir=${FLATPAK_DEST}/lib/ocaml
+          --docdir=${FLATPAK_DEST}/share/doc
+          --mandir=${FLATPAK_DEST}/share/man
+          --datadir=${FLATPAK_DEST}/share/data
+          --etcdir=${FLATPAK_DEST}/etc
       - make release
+      - ./dune.exe build --verbose --release @install
       - PREFIX=${FLATPAK_DEST} make install
+      # install the libraries too (e.g. dune-configurator)
+      - ./dune.exe install
 
   - name: scripts
     sources:


### PR DESCRIPTION
Currently only the dune executable is built and installed, but dune also offers libraries, such as "dune-configurator".

Unfortunately one of the libraries depends on "lwt" which requires dune to build, so use a Fedora patch to remove the dune-rpc-lwt library.

With this, "lablgtk3" can be built with dune.